### PR TITLE
For args that have skipValidation set to `true`, check if the parsed …

### DIFF
--- a/yargs.js
+++ b/yargs.js
@@ -793,7 +793,7 @@ function Yargs (processArgs, cwd, parentRequire) {
     // Check if any of the options to skip validation were provided
     if (!skipValidation && options.skipValidation.length > 0) {
       skipValidation = Object.keys(argv).some(function (key) {
-        return options.skipValidation.indexOf(key) >= 0
+        return options.skipValidation.indexOf(key) >= 0 && argv[key] === true
       })
     }
 


### PR DESCRIPTION
…arg is `true`

When an arg is defined, it will always exist in the parsed argv. Thus, validation would always be skipped, regardless of whether an arg that has `skipValidation` set to `true` is actually passed on the command line. This commit checks to see if the parsed argv value is actually set to true.